### PR TITLE
Add an import option to force TextureArrays as normal maps for RGTC

### DIFF
--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -138,7 +138,7 @@ void ResourceImporterLayeredTexture::get_import_options(List<ImportOption> *r_op
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "compress/lossy_quality", PROPERTY_HINT_RANGE, "0,1,0.01"), 0.7));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "compress/hdr_compression", PROPERTY_HINT_ENUM, "Disabled,Opaque Only,Always"), 1));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "compress/bptc_ldr", PROPERTY_HINT_ENUM, "Disabled,Enabled,RGBA Only"), 0));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "compress/channel_pack", PROPERTY_HINT_ENUM, "sRGB Friendly,Optimized"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "compress/channel_pack", PROPERTY_HINT_ENUM, "sRGB Friendly,Optimized, normal"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "mipmaps/generate"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "mipmaps/limit", PROPERTY_HINT_RANGE, "-1,256"), -1));
 
@@ -169,6 +169,7 @@ void ResourceImporterLayeredTexture::_save_tex(Vector<Ref<Image>> p_images, cons
 			if (p_force_po2) {
 				p_images.write[i]->resize_to_po2();
 			}
+			
 		}
 
 		if (p_mipmaps) {
@@ -249,7 +250,7 @@ void ResourceImporterLayeredTexture::_save_tex(Vector<Ref<Image>> p_images, cons
 			}
 
 			if (p_mipmaps) {
-				p_images.write[i]->generate_mipmaps();
+				p_images.write[i]->generate_mipmaps(p_csource == Image::COMPRESS_SOURCE_NORMAL);
 			} else {
 				p_images.write[i]->clear_mipmaps();
 			}
@@ -356,6 +357,10 @@ Error ResourceImporterLayeredTexture::import(const String &p_source_file, const 
 	Image::CompressSource csource = Image::COMPRESS_SOURCE_GENERIC;
 	if (channel_pack == 0) {
 		csource = Image::COMPRESS_SOURCE_SRGB;
+	}
+	else if( channel_pack == 2) {
+		// force normal
+		csource = Image::COMPRESS_SOURCE_NORMAL;
 	}
 
 	Image::UsedChannels used_channels = image->detect_used_channels(csource);


### PR DESCRIPTION
this is a redo of the pull request : https://github.com/godotengine/godot/pull/52058

i'm a noob on github and i deleted it. 

i have added the option to chose normal map for channel pack. this will force the to use red and green channels for the texture only. the option is added meaning it will not conflict with the existing settings.

i have made this change as a response to my own proposal

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
